### PR TITLE
Do not try to parse response if status is 204

### DIFF
--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -235,6 +235,10 @@ final class GuzzleHttpClient implements HttpClientInterface
      */
     private function parseResponse(ResponseInterface $response): array
     {
+        if ($response->getStatusCode() === 204) {
+            return [];
+        }
+
         try {
             return (array) json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {


### PR DESCRIPTION
Because 204 means there is no content. The json_decode function throws error with empty string. Especially in DELETE methods.