### PR TITLE
Use array_merge instead of array addition

### DIFF
--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -134,7 +134,7 @@ final class GuzzleHttpClient implements HttpClientInterface
                 ->request(
                     $method->name,
                     $uri,
-                    [
+                    array_merge([
                         'base_uri' => self::BASE_URI,
                         'http_errors' => false,
                         'headers' => [
@@ -144,7 +144,7 @@ final class GuzzleHttpClient implements HttpClientInterface
                         ],
                         'query' => $query,
                         'json' => $body,
-                    ] + $this->options,
+                    ], $this->options),
                 );
         } catch (Throwable $exception) {
             throw new HttpException($exception->getMessage());


### PR DESCRIPTION
So we can override options while initializing the client. My actual need is to override `base_uri` parameter because I use staging environment of Paraşüt.